### PR TITLE
Prevent strong example generation from hanging

### DIFF
--- a/Scenes_and_scripts/Algorithms/SolutionGeneration.gd
+++ b/Scenes_and_scripts/Algorithms/SolutionGeneration.gd
@@ -59,7 +59,7 @@ func generate_diagrams(
 	var degrees_to_check := get_degrees_to_check(
 		min_degree, max_degree, base_interaction_matrix
 	)
-
+	
 	var generated_connection_matrices : Array[ConnectionMatrix] = []
 	var base_matrix := convert_interaction_matrix_to_in_out(base_interaction_matrix)
 	
@@ -993,6 +993,9 @@ func connect_4interaction(
 ) -> Array[InteractionMatrix]:
 	var unconnected_particle_count: int = unconnected_particles.size()
 	var interaction_size: int = interaction.size()
+	
+	if len(interaction) < 3:
+		return []
 	
 	var particleA: ParticleData.Particle = interaction[0] as ParticleData.Particle
 	var particleB: ParticleData.Particle = interaction[1] as ParticleData.Particle

--- a/Scenes_and_scripts/Diagram/interaction.tscn
+++ b/Scenes_and_scripts/Diagram/interaction.tscn
@@ -225,7 +225,6 @@ offset_left = 7.0
 offset_top = -5.0
 offset_right = 22.0
 offset_bottom = 7.0
-text = "1"
 label_settings = SubResource("LabelSettings_hhkv1")
 vertical_alignment = 1
 


### PR DESCRIPTION
1. Make a fast color balancing check to quickly reject problems that have no color solution.
2. Abandon and restart problem generation if a valid solution is not found after 200 tries.

Also fixes a spurious '1' label on each vertex.